### PR TITLE
Fix build for KNIME AP 5.9

### DIFF
--- a/com.vernalis.knime.misc.blobs/META-INF/MANIFEST.MF
+++ b/com.vernalis.knime.misc.blobs/META-INF/MANIFEST.MF
@@ -14,6 +14,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.13.0,4.0.0)",
  org.knime.time;bundle-version="[4.7.0,6.0.0)",
  com.vernalis.knime.core;bundle-version="[1.0.0,2.0.0)",
  org.apache.commons.commons-compress;bundle-version="[1.26.0,2.0.0)",
- org.apache.commons.commons-io;bundle-version="[2.15.1,3.0.0)"
+ org.apache.commons.commons-io;bundle-version="[2.15.1,3.0.0)",
+ org.tukaani.xz;bundle-version="[1.10.0,2.0.0)",
+ com.github.luben.zstd-jni;bundle-version="[1.5.6,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: com.vernalis.knime.misc.blobs.VernalisKnimeMiscBlobsPlugin


### PR DESCRIPTION
The build for KNIME AP 5.9 would fail with:
```
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-compiler-plugin:4.0.8:compile (default-compile) on project com.vernalis.knime.misc.blobs: Compilation failure: Compilation failure: 
[ERROR] /Users/benjaminwilhelm/git/vernalis-knime-nodes/com.vernalis.knime.misc.blobs/src/com/vernalis/knime/misc/blobs/nodes/compress/CompressFormat.java:[1] 
[ERROR]         /*******************************************************************************
[ERROR]         ^
[ERROR] The type org.tukaani.xz.LZMAOutputStream cannot be resolved. It is indirectly referenced from required type org.apache.commons.compress.compressors.lzma.LZMACompressorOutputStream
[ERROR] /Users/benjaminwilhelm/git/vernalis-knime-nodes/com.vernalis.knime.misc.blobs/src/com/vernalis/knime/misc/blobs/nodes/compress/CompressFormat.java:[1] 
[ERROR]         /*******************************************************************************
[ERROR]         ^
[ERROR] The type org.tukaani.xz.XZOutputStream cannot be resolved. It is indirectly referenced from required type org.apache.commons.compress.compressors.xz.XZCompressorOutputStream
[ERROR] /Users/benjaminwilhelm/git/vernalis-knime-nodes/com.vernalis.knime.misc.blobs/src/com/vernalis/knime/misc/blobs/nodes/compress/CompressFormat.java:[1] 
[ERROR]         /*******************************************************************************
[ERROR]         ^
[ERROR] The type com.github.luben.zstd.ZstdOutputStream cannot be resolved. It is indirectly referenced from required type org.apache.commons.compress.compressors.zstandard.ZstdCompressorOutputStream
```

This indicates that the optional dependencies `org.tukaani.xz` and `com.github.luben.zstd-jni` of `org.apache.commons.commons-compress` now need to be listed explicitly because they are accessed by `CompressFormat`.